### PR TITLE
23.11 Release Notes: Streamline new-services

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311/sections/new-services/ebusd.md
+++ b/nixos/doc/manual/release-notes/rl-2311/sections/new-services/ebusd.md
@@ -1,0 +1,1 @@
+- [ebusd](https://ebusd.eu), a daemon for handling communication with eBUS devices connected to a 2-wire bus system ("energy bus" used by numerous heating systems). Available as [services.ebusd](#opt-services.ebusd.enable).

--- a/nixos/doc/manual/release-notes/rl-2311/sections/new-services/eris-server.md
+++ b/nixos/doc/manual/release-notes/rl-2311/sections/new-services/eris-server.md
@@ -1,0 +1,1 @@
+- [eris-server](https://codeberg.org/eris/eris-go), an implementation of the Encoding for Robust Immutable Storage (ERIS). Available as [services.eris-server](#opt-services.eris-server.enable).

--- a/nixos/doc/manual/release-notes/rl-2311/sections/new-services/fastnetmon-advanced.md
+++ b/nixos/doc/manual/release-notes/rl-2311/sections/new-services/fastnetmon-advanced.md
@@ -1,0 +1,1 @@
+- [FastNetMon Advanced](https://fastnetmon.com/product-overview/), a commercial high performance DDoS detector and sensor. Available as [services.fastnetmon-advanced](#opt-services.fastnetmon-advanced.enable).

--- a/nixos/doc/manual/release-notes/rl-2311/sections/new-services/forgejo.md
+++ b/nixos/doc/manual/release-notes/rl-2311/sections/new-services/forgejo.md
@@ -1,0 +1,1 @@
+- [forgejo](https://forgejo.org/), a git forge and drop-in replacement for Gitea. Available as [services.forgejo](#opt-services.forgejo.enable).

--- a/nixos/doc/manual/release-notes/rl-2311/sections/new-services/gotosocial.md
+++ b/nixos/doc/manual/release-notes/rl-2311/sections/new-services/gotosocial.md
@@ -1,0 +1,1 @@
+- [GoToSocial](https://gotosocial.org/), an ActivityPub social network server written in Golang. Available as [services.gotosocial](#opt-services.gotosocial.enable).

--- a/nixos/doc/manual/release-notes/rl-2311/sections/new-services/homeassistant-satellite.md
+++ b/nixos/doc/manual/release-notes/rl-2311/sections/new-services/homeassistant-satellite.md
@@ -1,0 +1,1 @@
+- [Home Assistant Satellite](https://github.com/synesthesiam/homeassistant-satellite), a streaming audio satellite for Home Assistant voice pipelines, where you can reuse existing mic and speaker hardware. Available as [services.homeassistant-satellite](#opt-services.homeassistant-satellite.enable).

--- a/nixos/doc/manual/release-notes/rl-2311/sections/new-services/honk.md
+++ b/nixos/doc/manual/release-notes/rl-2311/sections/new-services/honk.md
@@ -1,0 +1,1 @@
+- [Honk](https://humungus.tedunangst.com/r/honk), a complete ActivityPub server with minimal setup and support costs. Available as [services.honk](#opt-services.honk.enable).

--- a/nixos/doc/manual/release-notes/rl-2311/sections/new-services/infiniband.md
+++ b/nixos/doc/manual/release-notes/rl-2311/sections/new-services/infiniband.md
@@ -1,0 +1,1 @@
+- `hardware/infiniband.nix` adds infiniband subnet manager support using an [opensm](https://github.com/linux-rdma/opensm) systemd-template service, instantiated on card guids. The module also adds kernel modules and cli tooling to help administrators debug and measure performance. Available as [hardware.infiniband.enable](#opt-hardware.infiniband.enable).

--- a/nixos/doc/manual/release-notes/rl-2311/sections/new-services/jool.md
+++ b/nixos/doc/manual/release-notes/rl-2311/sections/new-services/jool.md
@@ -1,0 +1,1 @@
+- [Jool](https://nicmx.github.io/Jool/en/index.html), a kernelspace NAT64 and SIIT implementation providing translation between IPv4 and IPv6. Available as [networking.jool.enable](#opt-networking.jool.enable).

--- a/nixos/doc/manual/release-notes/rl-2311/sections/new-services/livebook.md
+++ b/nixos/doc/manual/release-notes/rl-2311/sections/new-services/livebook.md
@@ -1,0 +1,1 @@
+- [Livebook](https://livebook.dev/), an interactive notebook with support for Elixir, graphs, machine learning, and more. Available as [services.livebook](#opt-services.livebook).

--- a/nixos/doc/manual/release-notes/rl-2311/sections/new-services/mautrix-whatsapp.md
+++ b/nixos/doc/manual/release-notes/rl-2311/sections/new-services/mautrix-whatsapp.md
@@ -1,0 +1,1 @@
+- [mautrix-whatsapp](https://docs.mau.fi/bridges/go/whatsapp/index.html), a Matrix-WhatsApp puppeting bridge. Available as [services.mautrix-whatsapp](#opt-services.mautrix-whatsapp.enable).

--- a/nixos/doc/manual/release-notes/rl-2311/sections/new-services/mobilizon.md
+++ b/nixos/doc/manual/release-notes/rl-2311/sections/new-services/mobilizon.md
@@ -1,0 +1,1 @@
+- [Mobilizon](https://joinmobilizon.org/), a Fediverse platform for publishing events. Available as [services.mobilizon](#opt-services.mobilizon.enable).

--- a/nixos/doc/manual/release-notes/rl-2311/sections/new-services/netclient.md
+++ b/nixos/doc/manual/release-notes/rl-2311/sections/new-services/netclient.md
@@ -1,0 +1,1 @@
+- [netclient](https://github.com/gravitl/netclient), an automated WireGuard Management Client. Available as [services.netclient](#opt-services.netclient.enable).

--- a/nixos/doc/manual/release-notes/rl-2311/sections/new-services/nncp.md
+++ b/nixos/doc/manual/release-notes/rl-2311/sections/new-services/nncp.md
@@ -1,0 +1,1 @@
+- [NNCP](http://www.nncpgo.org/), nncp-daemon and nncp-caller services. Available as [programs.nncp.settings](#opt-programs.nncp.settings) and [services.nncp](#opt-services.nncp.caller.enable).

--- a/nixos/doc/manual/release-notes/rl-2311/sections/new-services/osquery.md
+++ b/nixos/doc/manual/release-notes/rl-2311/sections/new-services/osquery.md
@@ -1,0 +1,1 @@
+- [osquery](https://www.osquery.io/), a SQL powered operating system instrumentation, monitoring, and analytics. Available as [services.osquery](#opt-services.osquery.enable).

--- a/nixos/doc/manual/release-notes/rl-2311/sections/new-services/sitespeed-io.md
+++ b/nixos/doc/manual/release-notes/rl-2311/sections/new-services/sitespeed-io.md
@@ -1,0 +1,1 @@
+- [sitespeed-io](https://sitespeed.io), a tool that can generate metrics such as timings and diagnostics for websites. Available as [services.sitespeed-io](#opt-services.sitespeed-io.enable).

--- a/nixos/doc/manual/release-notes/rl-2311/sections/new-services/tuxedo-rs.md
+++ b/nixos/doc/manual/release-notes/rl-2311/sections/new-services/tuxedo-rs.md
@@ -1,0 +1,1 @@
+- [tuxedo-rs](https://github.com/AaronErhardt/tuxedo-rs), Rust utilities for interacting with hardware from TUXEDO Computers. Available as [hardware.tuxedo-rs](#opt-hardware.tuxedo).

--- a/nixos/doc/manual/release-notes/rl-2311/sections/new-services/virt-manager.md
+++ b/nixos/doc/manual/release-notes/rl-2311/sections/new-services/virt-manager.md
@@ -1,0 +1,1 @@
+- [virt-manager](https://virt-manager.org/), an UI for managing virtual machines in libvirt. Available as [programs.virt-manager](#opt-programs.virt-manager.enable).

--- a/nixos/doc/manual/release-notes/rl-2311/sections/new-services/wayfire.md
+++ b/nixos/doc/manual/release-notes/rl-2311/sections/new-services/wayfire.md
@@ -1,0 +1,1 @@
+- [wayfire](https://wayfire.org), a modular and extensible wayland compositor. Available as [programs.wayfire](#opt-programs.wayfire.enable).


### PR DESCRIPTION
This commit streamlines the entries in new-services.

Note:
- I deleted trunk-ng.md since it's not a new service but a package.
- It should be doublechecked that removing the trademark symbol to WireGuard is OK.
- I reframed some wording to not have it PR vibes.